### PR TITLE
remove telegram, add conversations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,8 +70,10 @@ The list is separated into topics and each service or software stated gives supp
 	- Does not log metadata
 - [Threema](https://threema.ch/en/)
 - [Ring](https://ring.cx/)
-- Telegram
-	- Uses its own MTProto cryptography protocol [which is not foul proof](https://www.reddit.com/r/privacy/comments/5mnzxr/facebook_messenger_alternatives/)
+- [Conversations](https://conversations.im/)
+	- built on XMPP/Jabber
+	- supports several well-audited encryption protocols
+	- you can talk with Conversations users via dozens of open source XMPP clients
 
 ## Cloud Storage 
 **⚠️ You are the product:**


### PR DESCRIPTION
Switched Telegram with Conversations. Telegram does not provide particularly good security (desktop client doesn't support end-to-end encryption at all, on mobile it's optional and your history doesn't get saved, and their protocol isn't up to standard, either), and it is yet another service tied to the app. Conversations uses a federated protocol that is tried and tested for decades, and your privacy is exactly as secure as your XMPP provider's logging policy - you can actually switch providers without installing yet another app.