### PR TITLE
Add CozyCloud to alternatives for cloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The list is separated into topics and each service or software stated gives supp
 - [Nextcloud](https://nextcloud.com/) - [About Nextcloud](https://nextcloud.com/about/). Self hosted.
 - [ownCloud](https://owncloud.org/) - [ownCloud Features](https://owncloud.org/features/). Self hosted + encryption app available.
 - [Keybase](https://keybase.io/) - Open-source end-to-end encrypted dropbox and GitHub alternative.
+- [CozyCloud](https://cozy.io) - [Privacy and CozyCloud](https://cozy.io/en/privacy/). Open Source + self hosted.
 
 ## Email
 **⚠️ You are the product:**


### PR DESCRIPTION
Hi, thanks for this list. I think CozyCloud should be in the list of alternatives for cloud storage, so I made a pull request to add it.