### PR TITLE
Add Tahoe-LAFS providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The list is separated into topics and each service or software stated gives supp
 - [Keybase](https://keybase.io/) - Open-source end-to-end encrypted dropbox and GitHub alternative.
 - [CozyCloud](https://cozy.io) - [Privacy and CozyCloud](https://cozy.io/en/privacy/). Open Source + self hosted.
 - [Mega](https://mega.nz) - [Privacy Company](https://mega.nz/privacycompany) - Open-source end-to-end encrypted.
+- [Tahoe-LAFS](https://tahoe-lafs.org/) - Capability-secure, end-to-end encryption, [provider-independent privacy](https://tahoe-lafs.readthedocs.io/en/latest/about.html) (storage providers cannot read stored data)
+  - [Least Authority](https://leastauthority.com/) - Paid personal Tahoe-LAFS grids
+  - [Matador Cloud](https://matador.cloud/) - Free global Tahoe-LAFS grid, paid services
 
 ## Email
 **⚠️ You are the product:**


### PR DESCRIPTION
Tahoe-LAFS is pretty cool. Check out https://tahoe-lafs.readthedocs.io/en/latest/about.html if you haven't seen it before.

There is at least one other paid Tahoe provider out there, but I cannot find their site and cannot remember their name.

Disclaimer: I own Matador Cloud LLC.