### PR TITLE
Add PureOS and e.foundation to OS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The list is separated into topics and each service or software stated gives supp
 - iOS - [iOS 10 security white paper](https://www.apple.com/business/docs/iOS_Security_Guide.pdf).
 - [Android with LineageOS](https://lineageos.org/about/)
 - [Android with Copperhead](https://copperhead.co/android/)
+- [Android with /e/](https://e.foundation) - Fully ungoogled mobile phone OS. [Privacy Facts](https://e.foundation/privacy-facts/)
 - macOS - [Apple privacy](https://www.apple.com/lae/privacy/).
 - [FreeBSD](https://www.freebsd.org) - [Privacy Policy](https://www.freebsd.org/privacy.html).
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The list is separated into topics and each service or software stated gives supp
 - [Android with /e/](https://e.foundation) - Fully ungoogled mobile phone OS. [Privacy Facts](https://e.foundation/privacy-facts/)
 - macOS - [Apple privacy](https://www.apple.com/lae/privacy/).
 - [FreeBSD](https://www.freebsd.org) - [Privacy Policy](https://www.freebsd.org/privacy.html).
+- [PureOS](https://pureos.net/) - Secure and freedom respecting. Soon also on smartphone: [Librem5](https://puri.sm/shop/librem-5/).
 
 ## Browsers
 **⚠️ You are the product:**


### PR DESCRIPTION
I have 2 new entries for the OS section, that I think are important to take into account.

e.foundation was started as a fork of LineageOS, but is rewriting a bunch of low-level proprietary software that is still related to Google and other non-privacy-respecting parties. /e/ has just entered beta-testing phase.

PureOS is the linux operating system that will soon be available on the pur.sm Librem5 smartphone, which is designed with _extreme_ care for privacy.