### PR TITLE
Added Cent to SN Alternatives & Tresorit to Cloud Storage Alternatives & Redacted MEGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ The list is separated into topics and each service or software stated gives supp
 - [ownCloud](https://owncloud.org/) - [ownCloud Features](https://owncloud.org/features/). Self hosted + encryption app available.
 - [Keybase](https://keybase.io/) - Open-source end-to-end encrypted Dropbox and GitHub alternative.
 - [CozyCloud](https://cozy.io) - [Privacy and CozyCloud](https://cozy.io/en/privacy/). Open Source + self hosted.
-- [Mega](https://mega.nz) - [Privacy Company](https://mega.nz/privacycompany) - Open-source end-to-end encrypted.
 - [SpiderOak ONE](https://spideroak.com) - End-to-end no-knowledge encryption, [Edward Snowden endorsed!](https://www.theguardian.com/technology/2014/jul/17/edward-snowden-dropbox-privacy-spideroak)
 - [Tahoe-LAFS](https://tahoe-lafs.org/) - Capability-secure, end-to-end encryption, [provider-independent privacy](https://tahoe-lafs.readthedocs.io/en/latest/about.html). Storage providers cannot read stored data.
   - [Least Authority](https://leastauthority.com/) - Paid personal Tahoe-LAFS grids.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The list is separated into topics and each service or software stated gives supp
 - [Minds](https://www.minds.com/) - Anonymous & open-source social network with encrypted conversations. [How Minds.com Protects Your Privacy](https://www.minds.com/blog/view/823256224013205504).
 - [Chttr](https://chttr.co/) - [Politically unbiased, privacy respecting social network](https://chttr.co/about).
 - [Pleroma](https://pleroma.social/) - [Pleroma instances](http://distsn.org/pleroma-instances.html).
+- [Cent](https://cent.co/) - Democratized social network built on Ethereum. [What is Cent?](https://medium.com/cent-official/cent-income-from-anywhere-519515b396d8)
 
 ## Messengers
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The list is separated into topics and each service or software stated gives supp
 - [Tahoe-LAFS](https://tahoe-lafs.org/) - Capability-secure, end-to-end encryption, [provider-independent privacy](https://tahoe-lafs.readthedocs.io/en/latest/about.html). Storage providers cannot read stored data.
   - [Least Authority](https://leastauthority.com/) - Paid personal Tahoe-LAFS grids.
   - [Matador Cloud](https://matador.cloud/) - Free global Tahoe-LAFS grid, paid services.
+- [Tresorit](https://tresorit.com/) - Swiss based end-to-end encrypted cloud storage.
 
 ## Email
 


### PR DESCRIPTION
Cent is a democratized social network that allows every user to monetize their own content and does not collect and distribute it's users data. Users can also be totally anonymous.

Tresorit is a Swiss based cloud storage provider. All data is end-to-end encrypted with zero-knowledge encryption. Tresorit is certified for ISO 27001, and facilitates compliance with GDPR, HIPAA and other security and data protection requirements.

Removed MEGA from cloud storage providers due to the seizure of the site and all assets by the New Zealand government in 2015. Additionally, due to new developments in Australian & New Zealand privacy laws, it is highly recommended to avoid any and all services hosted in or operated in either country.