### PR TITLE
Add OVPN as as privacy respecting VPN provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The list is separated into topics and each service or software stated gives supp
 
 - [ProtonVPN](https://protonvpn.com/) - As a Swiss VPN provider, Proton does not log user activity or share data with third parties. Tor is also supported.
 - [Mullvad](https://mullvad.net/) - Swedish based VPN provider that retains no logs, and uses a mostly open source and transparent infrastructure available to the public. Accepts Bitcoin, anonymous cash payments via envelope, PayPal, and more.
+- [OVPN](https://www.ovpn.com/) - Swedish provider that operates VPN servers without any hard drives, has a strict no logs policy, and publishes transparency reports. Accepts Bitcoin, anonymous cash payments, PayPal, and more.
 
 ## Email
 


### PR DESCRIPTION
OVPN is a privacy and security focused VPN provider with clear policies. We were the first VPN provider that operate servers without any hard drives ([2015](https://www.ovpn.com/en/blog/improvement-of-the-physical-security/)).

Security information: https://www.ovpn.com/en/security

Privacy policy: https://www.ovpn.com/en/privacypolicy
Transparency policy: https://www.ovpn.com/en/transparency
Terms of service: https://www.ovpn.com/en/tos

_Disclosure: I work for OVPN, but I strongly believe that we provide value being visible in this repository._
