### PR TITLE
Add Teddit to alternative front-ends

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ The list is separated into topics and each service or software stated gives supp
 - [Invidious](https://invidio.us) - Alternative front-end to YouTube. [Code](https://github.com/iv-org/invidious).
 - [Nitter](https://nitter.net) - Alternative Twitter front-end. [Code](https://github.com/zedeus/nitter).
 - [Libreddit](https://libredd.it) - Private front-end for Reddit written in Rust. [Code](https://github.com/spikecodes/libreddit).
+- [Teddit](https://teddit.net) - Alternative Reddit front-end focused on privacy. [Code](https://codeberg.org/teddit/teddit).
 - [Bibliogram](https://bibliogram.art) - An alternative front-end for Instagram. [Code](https://sr.ht/~cadence/bibliogram).
 
 ## Messengers


### PR DESCRIPTION
Initially found at: https://nitro.horse/@andreas/105290106046743588

And main usecase is:
> Great website to browse /r/privacytoolsio with nice UI and without JS
>
> [via @yerinalexey@mastodon.online](https://mastodon.online/@yerinalexey/105293353994234892)