### PR TITLE
Add recommendation about self-hosted email

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,7 @@ The list is separated into topics and each service or software stated gives supp
 - [CleanEmail](https://clean.email) – Manages your mailbox – group and organize, remove, label, and archive emails. [Full Privacy Policy](https://clean.email/privacy).
 - [Fastmail](https://fastmail.com) - Email, calendars, and contacts. [Privacy Policy](https://www.fastmail.com/about/privacy.html).
 - [Kolab Now](https://kolabnow.com) - Online service providing personal [Kolab Groupware](https://kolabenterprise.com) on desired level. [Privacy Statement](https://kolabnow.com/privacy).
+- [Self-host your own Email server](https://www.c0ffee.net/blog/mail-server-guide). Note that this route is not recommended unless you know exactly what you're doing, otherwise you might end up with terrible security on the server side.
 
 ## Operating Systems
 


### PR DESCRIPTION
Well, why not? In some cases that's the only good option. When almost all good services are blocked and others don't support IMAP/SMTP. That way I choose what to support and how to handle data.