### PR TITLE
Add Typer - free local AI chat for macOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,7 @@ The list is separated into topics and each service or software stated gives supp
 
 - [Mycroft](https://mycroft.ai/) - Open-source AI assistant, range of hardware options.
 - Apple Siri and HomePod - [Apple Privacy](https://www.apple.com/lae/privacy/).
+- [Typer](https://typer.space) - Free local AI chat for macOS (Apple Silicon). Runs entirely on-device — no account, no cloud, no ads. Works offline.
 
 ## Maps & Navigation
 


### PR DESCRIPTION
Typer is a free local AI chat app for macOS (Apple Silicon) that runs entirely on-device. No account required, no data sent to any server, no ads. It works fully offline.

It fits the AI Assistants section as a privacy-first alternative to cloud AI assistants — your conversations never leave your Mac.